### PR TITLE
Fix APP_BASE_PATH environment variable propagation

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,6 +53,7 @@ services:
     environment:
       - NODE_ENV=production
       - NODE_OPTIONS=--no-warnings
+      - APP_BASE_PATH=${APP_BASE_PATH:-/}
       - MONGO_DB=surveyjs
       - MONGO_USER=${MONGO_USER}
       - MONGO_PASSWORD=${MONGO_PASSWORD}


### PR DESCRIPTION
Add APP_BASE_PATH to app service environment section to ensure Portainer environment variables override .env file values. Defaults to / if not set.